### PR TITLE
Optimize: Read/Write Boolean

### DIFF
--- a/src/Csv/Csv.csproj
+++ b/src/Csv/Csv.csproj
@@ -12,6 +12,10 @@
           Visible="false" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFrameworks>net5.0;net6.0;net7.0;net8.0;netstandard2.1</TargetFrameworks>
     <LangVersion>12</LangVersion>

--- a/src/Csv/Internal/CsvConstants.cs
+++ b/src/Csv/Internal/CsvConstants.cs
@@ -1,0 +1,15 @@
+﻿namespace Csv.Internal;
+
+internal static class CsvConstants
+{
+    public const int TrueBytesLittleEndian = ((byte)'T') | ((byte)'r' << 8) | ((byte)'u' << 16) | ((byte)'e' << 24);
+    public const int trueBytesLittleEndian = ((byte)'t') | ((byte)'r' << 8) | ((byte)'u' << 16) | ((byte)'e' << 24);
+    public const int FalseBytesLittleEndian = ((byte)'F') | ((byte)'a' << 8) | ((byte)'l' << 16) | ((byte)'s' << 24);
+    public const int falseBytesLittleEndian = ((byte)'f') | ((byte)'a' << 8) | ((byte)'l' << 16) | ((byte)'s' << 24);
+
+
+    public const int TrueBytesBigEndian = ((byte)'T' << 24) | ((byte)'r' << 16) | ((byte)'u' << 8) | ((byte)'e');
+    public const int trueBytesBigEndian = ((byte)'t' << 24) | ((byte)'r' << 16) | ((byte)'u' << 8) | ((byte)'e');
+    public const int FalseBytesBigEndian = ((byte)'F' << 24) | ((byte)'a' << 16) | ((byte)'l' << 8) | ((byte)'s');
+    public const int falseBytesBigEndian = ((byte)'f' << 24) | ((byte)'a' << 16) | ((byte)'l' << 8) | ((byte)'s');
+}

--- a/src/Csv/Internal/SequenceReaderExtensions.cs
+++ b/src/Csv/Internal/SequenceReaderExtensions.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System.Buffers;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Csv.Internal;
+
+internal static class SequenceReaderExtensions
+{
+      [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static  bool TryRead(ref this SequenceReader<byte> reader, out int value) 
+        {
+            var currentSpan = reader.CurrentSpan;
+            var currentSpanIndex = reader.CurrentSpanIndex;
+            if (currentSpan.Length-currentSpanIndex < sizeof(int))
+                return TryReadMultisegment(ref reader, out value);
+
+            value = Unsafe.ReadUnaligned<int>(ref Unsafe.Add(ref MemoryMarshal.GetReference(currentSpan),currentSpanIndex));
+            reader.Advance(sizeof(int));
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static  bool TryReadMultisegment(ref SequenceReader<byte> reader, out int value) 
+        {
+
+            // Not enough data in the current segment, try to peek for the data we need.
+            int buffer = default;
+            Span<byte> tempSpan = MemoryMarshal.CreateSpan(ref Unsafe.As<int,byte>(ref buffer), 4);
+
+            if (!reader.TryCopyTo(tempSpan))
+            {
+                value = default;
+                return false;
+            }
+
+            value = Unsafe.ReadUnaligned<int>(ref MemoryMarshal.GetReference(tempSpan));
+            reader.Advance(sizeof(int));
+            return true;
+        }
+    
+    
+}

--- a/tests/Csv.Tests/CsvWriterTests.cs
+++ b/tests/Csv.Tests/CsvWriterTests.cs
@@ -83,4 +83,18 @@ public class CsvWriterTests
         csvWriter.WriteString("f\"oo");
         Assert.That(Encoding.UTF8.GetString(bufferWriter.WrittenSpan), Is.EqualTo(@"""f""""oo"""));
     }
+
+    [Test]
+    [TestCase(true, "true", QuoteMode.None)]
+    [TestCase(false, "false", QuoteMode.None)]
+    [TestCase(true, "\"true\"", QuoteMode.All)]
+    [TestCase(false, "\"false\"", QuoteMode.All)]
+    public void Test_WriteBoolean(bool b, string str, QuoteMode quoteMode)
+    {
+        var bufferWriter = new ArrayBufferWriter<byte>();
+        var csvWriter = new CsvWriter(bufferWriter, new() { QuoteMode = quoteMode });
+
+        csvWriter.WriteBoolean(b);
+        Assert.That(Encoding.UTF8.GetString(bufferWriter.WrittenSpan), Is.EqualTo(str));
+    }
 }


### PR DESCRIPTION
Deserialize/Serialize 100 Booleans.
```cs
[CsvObject]
public partial record Booleans
{
    [Column(0)]
    public bool Alpha { get; set; }

    [Column(1)]
    public bool Beta { get; set; }

    [Column(2)]
    public bool Gamma { get; set; }
}
```

```
BenchmarkDotNet v0.13.12, Windows 11 (10.0.26100.3194)
13th Gen Intel Core i7-13700F, 1 CPU, 24 logical and 16 physical cores
.NET SDK 9.0.200
  [Host]   : .NET 9.0.2 (9.0.225.6610), X64 RyuJIT AVX2
  ShortRun : .NET 9.0.2 (9.0.225.6610), X64 RyuJIT AVX2

Job=ShortRun  IterationCount=20  LaunchCount=1
WarmupCount=10

| Method            | Mean     | Error     | StdDev    | Gen0   | Allocated |
|------------------ |---------:|----------:|----------:|-------:|----------:|
| Deserialize       | 1.187 us | 0.0056 us | 0.0064 us | 0.1068 |   1.65 KB |
| Deserialize(Fork) | 966.3 ns | 2.55 ns   | 2.94 ns   | 0.1068 |   1.65 KB |


| Method          | Mean     | Error   | StdDev  | Gen0   | Allocated |
|---------------- |---------:|--------:|--------:|-------:|----------:|
| Serialize       | 550.2 ns | 2.62 ns | 2.91 ns | 0.0401 |     632 B |
| Serialize(Fork) | 490.0 ns | 5.78 ns | 6.65 ns | 0.0401 |     632 B |
```