### PR TITLE
fix: update coverlet.collector from 6.0.0 to 6.0.2

### DIFF
--- a/tests/Csv.Tests/Csv.Tests.csproj
+++ b/tests/Csv.Tests/Csv.Tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
coverlet.collector 6.0.0 bundles Newtonsoft.Json 9.0.1 inside its NuGet package, which is affected by CVE-2024-21907. Version 6.0.2 bundles Newtonsoft.Json 13.0.3, which includes the fix. Technically, this project is not affected by the vulnerability since coverlet.collector is only used in tests, not at runtime, but updating is still better than doing nothing.