### PR TITLE
feat: Support boolean type

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ array = CsvSerializer.Deserialize<Person>(csvText);
 
 Serialize has an overload that returns a UTF-8 encoded `byte[]`, and you can also pass a `Stream` or `IBufferWriter<byte>` for writing. Deserialize accepts UTF-8 byte arrays as `byte[]` and also supports `string`, `Stream`, and `ReadOnlySequence<byte>`.
 
-The default supported types for fields are `sbyte`, `byte`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `char`, `string`, `Enum`, `Nullable<T>`, `DateTime`, `TimeSpan`, and `Guid`. To support other types, refer to the Extensions section.
+The default supported types for fields are `bool`, `sbyte`, `byte`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `char`, `string`, `Enum`, `Nullable<T>`, `DateTime`, `TimeSpan`, and `Guid`. To support other types, refer to the Extensions section.
 
 ## Serialization
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -79,7 +79,7 @@ array = CsvSerializer.Deserialize<Person>(csvText);
 
 SerializeはUTF-8でエンコードされた`byte[]`を返すオーバーロードのほか、`Stream`や`IBufferWriter<byte>`を渡して書き込みを行うことも可能です。DeserializeはUTF-8バイト配列の`byte[]`を受け取るほか、`string`、`Stream`、`ReadOnlySequence<byte>`にも対応しています。
 
-フィールドに含める型は、デフォルトでは`sbyte`, `byte`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `char`, `string`, `Enum`, `Nullable<T>`, `DateTime`, `TimeSpan`, `Guid`に対応しています。これ以外の型に対応したい場合は機能拡張のセクションを参照してください。
+フィールドに含める型は、デフォルトでは`bool`, `sbyte`, `byte`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `char`, `string`, `Enum`, `Nullable<T>`, `DateTime`, `TimeSpan`, `Guid`に対応しています。これ以外の型に対応したい場合は機能拡張のセクションを参照してください。
 
 ## シリアライズ
 

--- a/src/Csv/Formatters/PrimitiveFormatters.cs
+++ b/src/Csv/Formatters/PrimitiveFormatters.cs
@@ -1,5 +1,20 @@
 namespace Csv.Formatters;
 
+public sealed class BoolFormatter : ICsvFormatter<bool>
+{
+    public static readonly BoolFormatter Instance = new();
+
+    public bool Deserialize(ref CsvReader reader)
+    {
+        return reader.ReadBoolean();
+    }
+
+    public void Serialize(ref CsvWriter writer, bool value)
+    {
+        writer.WriteBoolean(value);
+    }
+}
+
 public sealed class ByteFormatter : ICsvFormatter<byte>
 {
     public static readonly ByteFormatter Instance = new();

--- a/src/Csv/Formatters/StandardFormatterProvider.cs
+++ b/src/Csv/Formatters/StandardFormatterProvider.cs
@@ -6,6 +6,7 @@ public sealed class StandardFormatterProvider : ICsvFormatterProvider
 
     StandardFormatterProvider()
     {
+        Cache<bool>.value = BoolFormatter.Instance;
         Cache<sbyte>.value = SByteFormatter.Instance;
         Cache<byte>.value = ByteFormatter.Instance;
         Cache<short>.value = Int16Formatter.Instance;
@@ -35,9 +36,9 @@ public sealed class StandardFormatterProvider : ICsvFormatterProvider
             goto RETURN;
         }
 
-        if (typeof(T).GetGenericTypeDefinition() == typeof(Nullable<>))
+        if (typeof(T).IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(Nullable<>))
         {
-            Cache<T>.value = (ICsvFormatter<T>)Activator.CreateInstance(typeof(NullableFormatter<>).MakeGenericType(typeof(T)))!;
+            Cache<T>.value = (ICsvFormatter<T>)Activator.CreateInstance(typeof(NullableFormatter<>).MakeGenericType(Nullable.GetUnderlyingType(typeof(T))!))!;
             goto RETURN;
         }
 

--- a/tests/Csv.Tests/SerializeTests.cs
+++ b/tests/Csv.Tests/SerializeTests.cs
@@ -227,6 +227,63 @@ Charles,17
 
         CollectionAssert.AreEqual(expected, actual);
     }
+    [Test]
+    public void Test_Serialize_Bool()
+    {
+        BoolRecord[] records = [
+            new() { Name = "Alex", Active = true, Verified = true },
+            new() { Name = "Bob", Active = false, Verified = null },
+        ];
+
+        var bytes = CsvSerializer.Serialize(records);
+        var str = Encoding.UTF8.GetString(bytes);
+
+        Assert.That(str, Is.EqualTo(
+@"Name,Active,Verified
+Alex,true,true
+Bob,false,"
+        ));
+    }
+
+    [Test]
+    public void Test_Deserialize_Bool()
+    {
+        var csv =
+@"Name,Active,Verified
+Alex,true,true
+Bob,false,false
+Charles,True,True
+Dave,False,False
+Eve,TRUE,TRUE
+Frank,FALSE,FALSE"u8;
+
+        BoolRecord[] actual = CsvSerializer.Deserialize<BoolRecord>(new ReadOnlySequence<byte>(csv.ToArray()));
+        BoolRecord[] expected = [
+            new() { Name = "Alex", Active = true, Verified = true },
+            new() { Name = "Bob", Active = false, Verified = false },
+            new() { Name = "Charles", Active = true, Verified = true },
+            new() { Name = "Dave", Active = false, Verified = false },
+            new() { Name = "Eve", Active = true, Verified = true },
+            new() { Name = "Frank", Active = false, Verified = false },
+        ];
+
+        CollectionAssert.AreEqual(expected, actual);
+    }
+
+    [Test]
+    public void Test_Deserialize_Bool_Nullable_Empty()
+    {
+        var csv =
+@"Name,Active,Verified
+Alex,true,"u8;
+
+        BoolRecord[] actual = CsvSerializer.Deserialize<BoolRecord>(new ReadOnlySequence<byte>(csv.ToArray()));
+        BoolRecord[] expected = [
+            new() { Name = "Alex", Active = true, Verified = null },
+        ];
+
+        CollectionAssert.AreEqual(expected, actual);
+    }
 }
 
 [CsvObject]
@@ -236,4 +293,15 @@ public partial record User
     public string? Name { get; set; }
     [Column(1)]
     public int Age { get; set; }
+}
+
+[CsvObject]
+public partial record BoolRecord
+{
+    [Column(0)]
+    public string? Name { get; set; }
+    [Column(1)]
+    public bool Active { get; set; }
+    [Column(2)]
+    public bool? Verified { get; set; }
 }


### PR DESCRIPTION
- Support `bool` and `bool?` types for serialization/desrialization.
- Just add BoolFormatter and register it in Cache since `CsvReader` and `CsvWriter` already support a boolean value.