### PR TITLE
fix: csvWriter.WriteDouble cannot write double.Min/MaxValue

### DIFF
--- a/src/Csv/CsvWriter.Number.cs
+++ b/src/Csv/CsvWriter.Number.cs
@@ -234,9 +234,11 @@ partial struct CsvWriter
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteDouble(double value)
     {
+        const int MaxLength = 24; // for writing double.MinValue (-1.7976931348623157E+308)
+
         if (options.QuoteMode == QuoteMode.All)
         {
-            var span = GetSpan(22);
+            var span = GetSpan(MaxLength + 2);
             span[0] = (byte)'"';
             if (!Utf8Formatter.TryFormat(value, span[1..], out var bytesWritten))
             {
@@ -247,7 +249,7 @@ partial struct CsvWriter
         }
         else
         {
-            var span = GetSpan(20);
+            var span = GetSpan(MaxLength);
             if (!Utf8Formatter.TryFormat(value, span, out var bytesWritten))
             {
                 CsvSerializationException.ThrowFailedEncoding(value);

--- a/tests/Csv.Tests/CsvWriterTests.cs
+++ b/tests/Csv.Tests/CsvWriterTests.cs
@@ -97,4 +97,18 @@ public class CsvWriterTests
         csvWriter.WriteBoolean(b);
         Assert.That(Encoding.UTF8.GetString(bufferWriter.WrittenSpan), Is.EqualTo(str));
     }
+
+    [Test]
+    [TestCase(double.MaxValue, "1.7976931348623157E+308", QuoteMode.None)]
+    [TestCase(double.MinValue, "-1.7976931348623157E+308", QuoteMode.None)]
+    [TestCase(double.MaxValue, "\"1.7976931348623157E+308\"", QuoteMode.All)]
+    [TestCase(double.MinValue, "\"-1.7976931348623157E+308\"", QuoteMode.All)]
+    public void Test_WriteDouble_MaxAndMinValue(double value, string expected, QuoteMode quoteMode)
+    {
+        var bufferWriter = new ArrayBufferWriter<byte>();
+        var csvWriter = new CsvWriter(bufferWriter, new() { QuoteMode = quoteMode });
+
+        csvWriter.WriteDouble(value);
+        Assert.That(Encoding.UTF8.GetString(bufferWriter.WrittenSpan), Is.EqualTo(expected));
+    }
 }


### PR DESCRIPTION
Increase span size to write double.Min/MaxValue with quotations.