### PR TITLE
fix: CsvSerializer.Serialize yields double outputs

### DIFF
--- a/src/Csv/CsvSerializer.Serialize.cs
+++ b/src/Csv/CsvSerializer.Serialize.cs
@@ -56,9 +56,17 @@ public static partial class CsvSerializer
 
     public static void Serialize<T>(IBufferWriter<byte> bufferWriter, IEnumerable<T> values, CsvOptions? options = default)
     {
-        if (values is T[] array) Serialize<T>(bufferWriter, array.AsSpan(), options);
+        if (values is T[] array)
+        {
+            Serialize<T>(bufferWriter, array.AsSpan(), options);
+            return;
+        }
 #if NET5_0_OR_GREATER
-        if (values is List<T> list) Serialize<T>(bufferWriter, CollectionsMarshal.AsSpan(list), options);
+        if (values is List<T> list)
+        {
+            Serialize<T>(bufferWriter, CollectionsMarshal.AsSpan(list), options);
+            return;
+        }
 #endif
 
         options ??= DefaultOptions;
@@ -86,9 +94,17 @@ public static partial class CsvSerializer
 
     public static void Serialize<T>(Stream stream, IEnumerable<T> values, CsvOptions? options = default)
     {
-        if (values is T[] array) Serialize<T>(stream, array.AsSpan(), options);
+        if (values is T[] array)
+        {
+            Serialize<T>(stream, array.AsSpan(), options);
+            return;
+        }
 #if NET5_0_OR_GREATER
-        if (values is List<T> list) Serialize<T>(stream, CollectionsMarshal.AsSpan(list), options);
+        if (values is List<T> list)
+        {
+            Serialize<T>(stream, CollectionsMarshal.AsSpan(list), options);
+            return;
+        }
 #endif
 
         var writer = SharedBufferWriter.GetWriter();

--- a/tests/Csv.Tests/SerializeTests.cs
+++ b/tests/Csv.Tests/SerializeTests.cs
@@ -40,6 +40,92 @@ Charles,17"
     }
 
     [Test]
+    public void Test_Serialize_Stream_IEnumerable_Array()
+    {
+        User[] users = [
+            new() { Name = "Alex", Age = 21 },
+            new() { Name = "Bob", Age = 35 },
+            new() { Name = "Charles", Age = 17 }
+        ];
+        IEnumerable<User> values = users;
+        using var stream = new MemoryStream();
+
+        CsvSerializer.Serialize(stream, values);
+        var str = Encoding.UTF8.GetString(stream.ToArray());
+
+        Assert.That(str, Is.EqualTo(
+@"Name,Age
+Alex,21
+Bob,35
+Charles,17"
+        ));
+    }
+
+    [Test]
+    public void Test_Serialize_Stream_IEnumerable_List()
+    {
+        List<User> values = [
+            new() { Name = "Alex", Age = 21 },
+            new() { Name = "Bob", Age = 35 },
+            new() { Name = "Charles", Age = 17 }
+        ];
+        using var stream = new MemoryStream();
+
+        CsvSerializer.Serialize(stream, values);
+        var str = Encoding.UTF8.GetString(stream.ToArray());
+
+        Assert.That(str, Is.EqualTo(
+@"Name,Age
+Alex,21
+Bob,35
+Charles,17"
+        ));
+    }
+
+    [Test]
+    public void Test_Serialize_BufferWriter_IEnumerable_Array()
+    {
+        User[] users = [
+            new() { Name = "Alex", Age = 21 },
+            new() { Name = "Bob", Age = 35 },
+            new() { Name = "Charles", Age = 17 }
+        ];
+        IEnumerable<User> values = users;
+        var bufferWriter = new ArrayBufferWriter<byte>();
+
+        CsvSerializer.Serialize(bufferWriter, values);
+        var str = Encoding.UTF8.GetString(bufferWriter.WrittenSpan);
+
+        Assert.That(str, Is.EqualTo(
+@"Name,Age
+Alex,21
+Bob,35
+Charles,17"
+        ));
+    }
+
+    [Test]
+    public void Test_Serialize_BufferWriter_IEnumerable_List()
+    {
+        List<User> values = [
+            new() { Name = "Alex", Age = 21 },
+            new() { Name = "Bob", Age = 35 },
+            new() { Name = "Charles", Age = 17 }
+        ];
+        var bufferWriter = new ArrayBufferWriter<byte>();
+
+        CsvSerializer.Serialize(bufferWriter, values);
+        var str = Encoding.UTF8.GetString(bufferWriter.WrittenSpan);
+
+        Assert.That(str, Is.EqualTo(
+@"Name,Age
+Alex,21
+Bob,35
+Charles,17"
+        ));
+    }
+
+    [Test]
     public void Test_Serialize_WithQuote()
     {
         User[] users = [


### PR DESCRIPTION
Add missing returns for Serialize methods.